### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "type": "git",
     "url": "https://github.com/BenAhrdt/ioBroker.janitza-gridvis"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "node-schedule": "^2.1.1"


### PR DESCRIPTION
Adapter-core 3.x.x is known to fail when installed at node 14 or lower due to npm 6 not installing peer-dependencies. So this adapter needs node 16 or newer.